### PR TITLE
chore: only lint the src directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Brandon Fulco <brandon.fulco@deque.com>",
   "license": "Unlicensed",
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint ./src",
     "fmt": "prettier --write .",
     "prebuild": "rimraf dist",
     "build": "ncc build --source-map src/main.ts"


### PR DESCRIPTION
The tests for this project are currently failing because the linter is running on much more than the source files. This change limits the linter to the ./src directory.