### PR TITLE
fix: transition from node16 to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ inputs:
     required: false
     default: "VPAT"
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
 branding:
   icon: 'activity'


### PR DESCRIPTION
Issue https://github.com/dequelabs/action-a11y-issue-labeler/issues/10

Node 16 is deprecated and we now need to use Node 20 in our actions.

> Node 16 has reached its [end of life](https://github.com/nodejs/Release/#end-of-life-releases), prompting us to initiate its deprecation process for GitHub Actions. Our plan is to transition all actions to run on Node 20 by Spring 2024. We will actively monitor the migration's progress and gather community feedback before finalizing the transition date. Starting October 23rd, workflows containing actions running on Node 16 will display a warning to alert users about the upcoming migration.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/